### PR TITLE
Calculate desired delay

### DIFF
--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -35,7 +35,10 @@ http {
         })
 
         local key = ngx.req.get_uri_args()['key']
-        local limit_exceeding = my_throttle:process(key)
+        local limit_exceeding, err = my_throttle:process(key)
+        if err then
+          return ngx.exit(500)
+        end
         if limit_exceeding then
           return ngx.exit(429)
         end
@@ -60,7 +63,10 @@ http {
         })
 
         local key = ngx.req.get_uri_args()['key']
-        local limit_exceeding = my_throttle:process(key)
+        local limit_exceeding, err = my_throttle:process(key)
+        if err then
+          return ngx.exit(500)
+        end
         if limit_exceeding then
           return ngx.exit(429)
         end

--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -14,8 +14,6 @@ http {
   default_type  application/octet-stream;
 
   lua_shared_dict counters 1m;
-  lua_shared_dict decision_cache 1m;
-  lua_shared_dict decision_cache_memc 1m;
 
   keepalive_timeout  65;
 
@@ -28,10 +26,13 @@ http {
     listen       8080;
     server_name  localhost;
 
-    location / {
+    location /dict {
       rewrite_by_lua_block {
         local global_throttle = require("resty.global_throttle")
-        local my_throttle, err = global_throttle.new(10, 2,  ngx.shared.decision_cache, { provider = "shared_dict", name = "counters" })
+        local my_throttle, err = global_throttle.new(10, 2, {
+          provider = "shared_dict",
+          name = "counters"
+        })
 
         local key = ngx.req.get_uri_args()['key']
         local limit_exceeding = my_throttle:process(key)
@@ -49,10 +50,11 @@ http {
     location /memc {
       rewrite_by_lua_block {
         local global_throttle = require("resty.global_throttle")
-        local my_throttle, err = global_throttle.new(10, 2,  ngx.shared.decision_cache_memc, {
+        local my_throttle, err = global_throttle.new(10, 2, {
           provider = "memcached",
           host = os.getenv("MEMCACHED_HOST"),
           port = os.getenv("MEMCACHED_PORT"),
+          connect_timeout = 15,
           max_idle_timeout = 10000,
           pool_size = 100,
         })
@@ -66,6 +68,18 @@ http {
 
       content_by_lua_block {
         ngx.say("Halo!")
+      }
+    }
+
+    location /all {
+      content_by_lua_block {
+        ngx.say("Halo!")
+      }
+    }
+
+    location /nothing {
+      rewrite_by_lua_block {
+        return ngx.exit(429)
       }
     }
   }

--- a/lib/resty/global_throttle/sliding_window.lua
+++ b/lib/resty/global_throttle/sliding_window.lua
@@ -22,14 +22,20 @@ local function get_counter_key(self, sample, time)
   return string_format("%s.%s.counter", sample, id)
 end
 
-local function last_sample_count(self, sample, now_ms)
+local function get_last_rate(self, sample, now_ms)
   local a_window_ago_from_now = now_ms - self.window_size
   local last_counter_key = get_counter_key(self, sample, a_window_ago_from_now)
 
-  return self.store:get(last_counter_key) or 0
+  -- NOTE(elvinefendi): returning 0 as a default value here means
+  -- we will allow spike in the first window or in the window that
+  -- has no immediate previous window with samples.
+  -- What if we default to self.limit here?
+  local last_count = self.store:get(last_counter_key) or 0
+
+  return last_count / self.window_size
 end
 
-function _M.new(store, window_size)
+function _M.new(store, limit, window_size)
   if not store then
     return nil, "'store' parameter is missing"
   end
@@ -42,6 +48,7 @@ function _M.new(store, window_size)
 
   return setmetatable({
     store = store,
+    limit = limit,
     window_size = window_size or DEFAULT_WINDOW_SIZE, -- milliseconds
   }, mt), nil
 end
@@ -61,25 +68,54 @@ function _M.add_sample(self, sample)
   return nil
 end
 
-function _M.estimated_total_count(self, sample)
+function _M.is_limit_exceeding(self, sample)
   local now_ms = ngx_now() * 1000
 
   local counter_key = get_counter_key(self, sample, now_ms)
 
   local count, err = self.store:get(counter_key)
   if err then
-    return nil, err
+    return nil, nil, err
   end
   if not count then
     count = 0
   end
 
-  local last_count = last_sample_count(self, sample, now_ms)
-  local last_rate = last_count / self.window_size
+  local last_rate = get_last_rate(self, sample, now_ms)
   local elapsed_time = now_ms % self.window_size
-  local estimated_total_count = last_rate * (self.window_size - elapsed_time) + count
+  local estimated_total_count =
+    last_rate * (self.window_size - elapsed_time) + count
 
-  return estimated_total_count, nil
+  local limit_exceeding = estimated_total_count >= self.limit
+  local delay_ms = nil
+
+  if limit_exceeding then
+    if last_rate == 0 then
+      -- When the last rate is 0, and limit is exceeding that means the limit
+      -- in the current window is precisely met (without estimation,
+      -- refer to the above formula). Which means we have to wait until the
+      -- next window to allow more samples.
+      delay_ms = self.window_size - elapsed_time
+    else
+      -- The following formula is obtained by solving the following equation
+      -- for `delay_ms`:
+      -- last_rate * (self.window_size - (elapsed_time + delay_ms)) + count =
+      --   self.limit - 1
+      -- This equation is comparable to total count estimation for the current
+      -- window formula above. Basically the idea is, how long more (delay_ms)
+      -- should we wait before estimated total count is below the limit again.
+      delay_ms =
+        self.window_size - (self.limit - count) / last_rate - elapsed_time
+    end
+
+    -- Unless weird time drifts happen or counter is borked, this should never
+    -- happen.
+    if not (delay_ms <= self.window_size or delay_ms > 0) then
+      return limit_exceeding, nil, "wrong value for delay_ms: " .. delay_ms
+    end
+  end
+
+  return limit_exceeding, delay_ms, nil
 end
 
 return _M


### PR DESCRIPTION
Instead of merely reporting weather the client should be throttled or not, the API now is also going to tell how long the client should be rejected before the rate is below the limit.