### PR TITLE
fix conditional and allow 0 delay

### DIFF
--- a/lib/resty/global_throttle/sliding_window.lua
+++ b/lib/resty/global_throttle/sliding_window.lua
@@ -108,9 +108,9 @@ function _M.is_limit_exceeding(self, sample)
         self.window_size - (self.limit - count) / last_rate - elapsed_time
     end
 
-    -- Unless weird time drifts happen or counter is borked, this should never
-    -- happen.
-    if not (delay_ms <= self.window_size or delay_ms > 0) then
+    -- Unless weird time drifts happen or counter is borked,
+    -- this should never be true.
+    if delay_ms > self.window_size or delay_ms < 0 then
       return limit_exceeding, nil, "wrong value for delay_ms: " .. delay_ms
     end
   end


### PR DESCRIPTION
fixes a conditional bug introduced in https://github.com/ElvinEfendi/lua-resty-global-throttle/pull/11, and also changes the logic to allow 0 delay. When delay is 0, it just means disallow current request, but start allowing from next one immediately without any delay.