### PR TITLE
Delete unnecessary logic when coping with racy behaviour

### DIFF
--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -37,7 +37,7 @@ http {
         local key = ngx.req.get_uri_args()['key']
         local estimated_final_count, desired_delay, err = my_throttle:process(key)
         if err then
-          ngx.log(ngx.ERR, "error when processing key", err)
+          ngx.log(ngx.ERR, "error when processing key: ", err)
           return ngx.exit(500)
         end
         if desired_delay then
@@ -66,7 +66,7 @@ http {
         local key = ngx.req.get_uri_args()['key']
         local estimated_final_count, desired_delay, err = my_throttle:process(key)
         if err then
-          ngx.log(ngx.ERR, "error when processing key", err)
+          ngx.log(ngx.ERR, "error when processing key: ", err)
           return ngx.exit(500)
         end
         if desired_delay then


### PR DESCRIPTION
Instead of re-estimating total count using the previous rate we only check if current counter value after the increment is over/at the limit after ignoring the current occurence of the sample. Imagine the limit is 10, and counter value is 8 when 3 sliding window instance try to increment it at the same time. In this case we will get 9, 10, and 11 as a new count, and after adjusting they will become 8, 9, 10. So we will throttle only then one seeing 10. And everything after this until the new window.