### PR TITLE
Expose remaining time as return value

### DIFF
--- a/examples/nginx.conf
+++ b/examples/nginx.conf
@@ -81,6 +81,14 @@ http {
       }
     }
 
+    location /output {
+      content_by_lua_block {
+        
+        require("examples").process_output()
+        ngx.say("ok")
+      }
+    }
+
     location /nothing {
       rewrite_by_lua_block {
         return ngx.exit(429)


### PR DESCRIPTION
This exposes the remaining_time variable as a return value from the process_sample function.