### PR TITLE
Global rate limit is not accurate: 10 limit tps, but can reach 30 tps

### DIFF
--- a/lib/resty/global_throttle/sliding_window.lua
+++ b/lib/resty/global_throttle/sliding_window.lua
@@ -64,12 +64,12 @@ function _M.new(namespace, store, limit, window_size)
   }, mt), nil
 end
 
-local function get_desired_delay(self, remaining_time, last_rate, count)
-  if last_rate == 0 then
+local function get_desired_delay(self, remaining_time, cur_rate, count)
+  if cur_rate == 0 then
     return remaining_time
   end
 
-  local desired_delay = remaining_time - (self.limit - count) / last_rate
+  local desired_delay = remaining_time - (self.limit - count) / cur_rate
 
   if desired_delay == 0 then
     -- no delay
@@ -82,7 +82,7 @@ local function get_desired_delay(self, remaining_time, last_rate, count)
   if desired_delay < 0 or desired_delay > self.window_size then
     ngx_log(ngx_ERR, "unexpected value for delay: ", desired_delay,
       ", when remaining_time = ", remaining_time,
-      " last_rate = ", last_rate,
+      " last_rate = ", cur_rate,
       " count = ", count,
       " limit = ", self.limit,
       " window_size = ", self.window_size)
@@ -141,10 +141,11 @@ function _M.process_sample(self, sample)
     return nil, nil, err
   end
 
-  local estimated_final_count = last_rate * remaining_time + count
+  local cur_rate = (last_rate * remaining_time + count) / self.window_size
+  local estimated_final_count = cur_rate * remaining_time + count
   if estimated_final_count >= self.limit then
     local desired_delay =
-      get_desired_delay(self, remaining_time, last_rate, count)
+      get_desired_delay(self, remaining_time, cur_rate, count)
     return estimated_final_count, desired_delay, nil
   end
 

--- a/lib/resty/global_throttle/sliding_window.lua
+++ b/lib/resty/global_throttle/sliding_window.lua
@@ -37,14 +37,6 @@ local function get_last_rate(self, sample, now_ms)
     -- What if we default to self.limit here?
     last_count = 0
   end
-  if last_count > self.limit then
-    -- in process_sample we also reactively check for exceeding limit
-    -- after icnrementing the counter. So even though counter can be higher
-    -- than the limit as a result of racy behaviour we would still throttle
-    -- anyway. That is way it is important to correct the last count here
-    -- to avoid over-punishment.
-    last_count = self.limit
-  end
 
   return last_count / self.window_size
 end
@@ -84,6 +76,9 @@ local function get_desired_delay(self, remaining_time, last_rate, count)
     return nil
   end
 
+  if desired_delay > remaining_time then
+    return remaining_time
+  end
   if desired_delay < 0 or desired_delay > self.window_size then
     ngx_log(ngx_ERR, "unexpected value for delay: ", desired_delay,
       ", when remaining_time = ", remaining_time,

--- a/lib/resty/global_throttle/sliding_window.lua
+++ b/lib/resty/global_throttle/sliding_window.lua
@@ -79,14 +79,9 @@ local function get_desired_delay(self, remaining_time, cur_rate, count)
   if desired_delay > remaining_time then
     return remaining_time
   end
-  if desired_delay < 0 or desired_delay > self.window_size then
-    ngx_log(ngx_ERR, "unexpected value for delay: ", desired_delay,
-      ", when remaining_time = ", remaining_time,
-      " last_rate = ", cur_rate,
-      " count = ", count,
-      " limit = ", self.limit,
-      " window_size = ", self.window_size)
-    return nil
+
+  if desired_delay <= 0 then
+      return nil;
   end
 
   return desired_delay


### PR DESCRIPTION
When I using ingress-nginx controller on k8s, and enable global rate limit. But find that the limit tps does not work well.

ingress-nginx controller cm
```
global-rate-limit-memcached-connect-timeout:50ms
global-rate-limit-memcached-host:memcached.ingress-nginx.svc.cluster.local
global-rate-limit-memcached-max-idle-timeout:50ms
global-rate-limit-memcached-pool-size: "10000"
global-rate-limit-memcached-port:"11211"
```

app ingress
```
apiVersion: v1
items:
- apiVersion: networking.k8s.io/v1
  kind: Ingress
  metadata:
    annotations:
      nginx.ingress.kubernetes.io/global-rate-limit: "10"
      nginx.ingress.kubernetes.io/global-rate-limit-key: $request_uri
      nginx.ingress.kubernetes.io/global-rate-limit-window: 1s
    creationTimestamp: "2024-01-18T02:29:56Z"
    generation: 1
    name: demo-localhost
    namespace: henry-test
    resourceVersion: "28783032"
    uid: fd40379e-f635-4533-90bc-0f4b56ce7430
  spec:
    ingressClassName: nginx
    rules:
    - host: demo.localdev.me
      http:
        paths:
        - backend:
            service:
              name: demo
              port:
                number: 80
          path: /
          pathType: Prefix
  status:
    loadBalancer:
      ingress:
      - ip: 3.239.19.65
kind: List
metadata:
  resourceVersion: ""

```


Using wrk test
<img width="986" alt="image" src="https://github.com/ElvinEfendi/lua-resty-global-throttle/assets/142382355/7885a067-c856-423e-b73d-904e521f9909">

After modifying code, it looks better
<img width="927" alt="image" src="https://github.com/ElvinEfendi/lua-resty-global-throttle/assets/142382355/082b598f-3090-48ea-b657-74a7ced52861">

